### PR TITLE
Update report title and columns

### DIFF
--- a/src/pages/insights/content/index.tsx
+++ b/src/pages/insights/content/index.tsx
@@ -62,7 +62,7 @@ const Content = () => {
   return (
     <ContentWrapper>
       <InnerContentWrapper>
-        <Title>Entitlement Report</Title>
+        <Title>Global User Access Report</Title>
         <FormWrapper>
           <Form onSubmit={handleSubmit}>
             <div className="flex flex-col gap-3">

--- a/src/pages/report2/content/index.tsx
+++ b/src/pages/report2/content/index.tsx
@@ -128,10 +128,10 @@ const Content = () => {
                   <th className="px-4 py-2">Source</th>
                   <th className="px-4 py-2">Account</th>
                   <th className="px-4 py-2">Account Type</th>
-                  <th className="px-4 py-2">Privileged Account</th>
+                  {/* <th className="px-4 py-2">Privileged Account</th> */}
                   <th className="px-4 py-2">Entitlement</th>
                   <th className="px-4 py-2">Entitlement Type</th>
-                  <th className="px-4 py-2">Privileged Entitlement</th>
+                  {/* <th className="px-4 py-2">Privileged Entitlement</th> */}
                 </tr>
               </thead>
               <tbody>
@@ -148,10 +148,10 @@ const Content = () => {
                       <td className="px-4 py-2">{row.source}</td>
                       <td className="px-4 py-2">{row.account}</td>
                       <td className="px-4 py-2">{row.accountType}</td>
-                      <td className="px-4 py-2">{row.accountPrivileged}</td>
+                      {/* <td className="px-4 py-2">{row.accountPrivileged}</td> */}
                       <td className="px-4 py-2">{row.entitlement}</td>
                       <td className="px-4 py-2">{row.entitlementType}</td>
-                      <td className="px-4 py-2">{row.entitlementPrivileged}</td>
+                      {/* <td className="px-4 py-2">{row.entitlementPrivileged}</td> */}
                     </tr>
                     {expandedIndex === index && (
                       <tr>


### PR DESCRIPTION
- Updated the Entitlement report name to match the left nav.
- Commented out the privileged account and privileged entitlement columns in the Orphan report as there was no data.